### PR TITLE
Change `at-mixin-argumentless-call-parentheses` rule to `always`

### DIFF
--- a/scss/index.js
+++ b/scss/index.js
@@ -10,7 +10,7 @@ module.exports = {
     'scss/at-function-named-arguments': 'never',
     'scss/at-function-parentheses-space-before': 'never',
     'scss/at-import-no-partial-leading-underscore': true,
-    'scss/at-mixin-argumentless-call-parentheses': null,
+    'scss/at-mixin-argumentless-call-parentheses': 'always',
     'scss/at-mixin-named-arguments': null,
     'scss/at-mixin-parentheses-space-before': 'never',
     'scss/at-rule-no-unknown': true,


### PR DESCRIPTION
Add rule - Always require parentheses in mixin calls, even if no arguments are passed.

Refs: https://github.com/twbs/bootstrap/pull/28720#discussion_r280979559