### PR TITLE
Bump dependencies.

### DIFF
--- a/css/index.js
+++ b/css/index.js
@@ -276,6 +276,7 @@ module.exports = {
     'selector-no-vendor-prefix': true,
     'shorthand-property-no-redundant-values': true,
     'string-quotes': 'double',
+    'unicode-bom': 'never',
     'value-keyword-case': 'lower',
     'value-list-comma-newline-after': 'never-multi-line',
     'value-list-comma-newline-before': 'never-multi-line',

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,14 +66,14 @@
       "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
     },
     "lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "postcss": {
-      "version": "7.0.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-      "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+      "version": "7.0.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.18.tgz",
+      "integrity": "sha512-/7g1QXXgegpF+9GJj4iN7ChGF40sYuGYJ8WZu8DZWnmhQ/G36hfdk3q9LBJmoK+lZ+yzZ5KYpOoxq7LF1BxE8g==",
       "requires": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",
@@ -101,18 +101,18 @@
       }
     },
     "postcss-sorting": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-4.1.0.tgz",
-      "integrity": "sha512-r4T2oQd1giURJdHQ/RMb72dKZCuLOdWx2B/XhXN1Y1ZdnwXsKH896Qz6vD4tFy9xSjpKNYhlZoJmWyhH/7JUQw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-5.0.1.tgz",
+      "integrity": "sha512-Y9fUFkIhfrm6i0Ta3n+89j56EFqaNRdUKqXyRp6kvTcSXnmgEjaVowCXH+JBe9+YKWqd4nc28r2sgwnzJalccA==",
       "requires": {
-        "lodash": "^4.17.4",
-        "postcss": "^7.0.0"
+        "lodash": "^4.17.14",
+        "postcss": "^7.0.17"
       }
     },
     "postcss-value-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
+      "integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ=="
     },
     "source-map": {
       "version": "0.6.1",
@@ -120,46 +120,46 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "stylelint-config-recommended": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-2.2.0.tgz",
-      "integrity": "sha512-bZ+d4RiNEfmoR74KZtCKmsABdBJr4iXRiCso+6LtMJPw5rd/KnxUWTxht7TbafrTJK1YRjNgnN0iVZaJfc3xJA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-3.0.0.tgz",
+      "integrity": "sha512-F6yTRuc06xr1h5Qw/ykb2LuFynJ2IxkKfCMf+1xqPffkxh0S09Zc902XCffcsw/XMFq/OzQ1w54fLIDtmRNHnQ=="
     },
     "stylelint-config-recommended-scss": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-3.3.0.tgz",
-      "integrity": "sha512-BvuuLYwoet8JutOP7K1a8YaiENN+0HQn390eDi0SWe1h7Uhx6O3GUQ6Ubgie9b/AmHX4Btmp+ZzVGbzriFTBcA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-4.0.0.tgz",
+      "integrity": "sha512-aEy0ENUrH4ASgFCu2mMcqBUAX0l4CPXg0XucJXdW+I7mdqJ7ICddkxP1eamBNBZ1QToc/wsuLmTQcalk3qYpsw==",
       "requires": {
-        "stylelint-config-recommended": "^2.2.0"
+        "stylelint-config-recommended": "^3.0.0"
       }
     },
     "stylelint-config-standard": {
-      "version": "18.3.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-18.3.0.tgz",
-      "integrity": "sha512-Tdc/TFeddjjy64LvjPau9SsfVRexmTFqUhnMBrzz07J4p2dVQtmpncRF/o8yZn8ugA3Ut43E6o1GtjX80TFytw==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-19.0.0.tgz",
+      "integrity": "sha512-VvcODsL1PryzpYteWZo2YaA5vU/pWfjqBpOvmeA8iB2MteZ/ZhI1O4hnrWMidsS4vmEJpKtjdhLdfGJmmZm6Cg==",
       "requires": {
-        "stylelint-config-recommended": "^2.2.0"
+        "stylelint-config-recommended": "^3.0.0"
       }
     },
     "stylelint-order": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-2.2.1.tgz",
-      "integrity": "sha512-019KBV9j8qp1MfBjJuotse6MgaZqGVtXMc91GU9MsS9Feb+jYUvUU3Z8XiClqPdqJZQ0ryXQJGg3U3PcEjXwfg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-3.1.1.tgz",
+      "integrity": "sha512-4gP/r8j/6JGZ/LL41b2sYtQqfwZl4VSqTp7WeIwI67v/OXNQ08dnn64BGXNwAUSgb2+YIvIOxQaMzqMyQMzoyQ==",
       "requires": {
-        "lodash": "^4.17.10",
-        "postcss": "^7.0.2",
-        "postcss-sorting": "^4.1.0"
+        "lodash": "^4.17.15",
+        "postcss": "^7.0.17",
+        "postcss-sorting": "^5.0.1"
       }
     },
     "stylelint-scss": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.6.0.tgz",
-      "integrity": "sha512-Qpw0gl6iLBon5JNeFZjVYOEayd/e+WYIdY2vFhZuXeHC6jb8wl0wRZY97jATt/uxZzdtU3tGLAvJOUMuFp18vw==",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.11.1.tgz",
+      "integrity": "sha512-0FZNSfy5X2Or4VRA3Abwfrw1NHrI6jHT8ji9xSwP8Re2Kno0i90qbHwm8ohPO0kRB1RP9x1vCYBh4Tij+SZjIg==",
       "requires": {
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "postcss-media-query-parser": "^0.2.3",
         "postcss-resolve-nested-selector": "^0.1.1",
         "postcss-selector-parser": "^6.0.2",
-        "postcss-value-parser": "^3.3.1"
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -24,16 +24,16 @@
     "scss/index.js"
   ],
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "peerDependencies": {
-    "stylelint": "^9.0.0 || ^10.0.0"
+    "stylelint": "^10.1.0 || ^11.0.0"
   },
   "dependencies": {
-    "stylelint-config-recommended-scss": "^3.3.0",
-    "stylelint-config-standard": "^18.3.0",
-    "stylelint-order": "^2.2.1",
-    "stylelint-scss": "^3.6.0"
+    "stylelint-config-recommended-scss": "^4.0.0",
+    "stylelint-config-standard": "^19.0.0",
+    "stylelint-order": "^3.1.1",
+    "stylelint-scss": "^3.11.1"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
stylelint 10.1.0 || 11.0.0 is needed. Also Node.js < 8 is dropped.

Needs testing with our master upstream branch.

Also, we should decide how to proceed with the version and git branches. Should we keep a `0.x` branch since in v4-dev we still support Node.js 6.x?

Also, this should be a major version bump, which means it's a good time to make any other breaking changes.

TODO:

- [ ] decide about the version and branches
- [x] check if `unicode-bom` is included in the configs we include otherwise include it