### PR TITLE
Clean up a few rules.

### DIFF
--- a/css/index.js
+++ b/css/index.js
@@ -34,16 +34,9 @@ module.exports = {
     'function-url-no-scheme-relative': true,
     'function-url-quotes': 'always',
     'length-zero-no-unit': true,
-    'max-empty-lines': 4,
+    'max-empty-lines': 2,
     'max-line-length': null,
-    'media-feature-name-no-unknown': [
-      true,
-      {
-        'ignoreMediaFeatureNames': [
-          'prefers-reduced-motion'
-        ]
-      }
-    ],
+    'media-feature-name-no-unknown': true,
     'media-feature-name-no-vendor-prefix': true,
     'media-feature-parentheses-space-inside': 'never',
     'media-feature-range-operator-space-after': 'always',


### PR DESCRIPTION
* reduce `max-empty-lines` to 2
* stop ignoring `prefers-reduced-motion` in `media-feature-name-no-unknown`; this does not seem to be needed anymore

I tested this on master, but would be nice if someone could test it in v4-dev too.

After we merge this we should release a new minor version.