### PR TITLE
Remove more inherited rules

### DIFF
--- a/css/index.js
+++ b/css/index.js
@@ -10,7 +10,6 @@ module.exports = {
   'rules': {
     'at-rule-empty-line-before': null,
     'at-rule-name-space-after': 'always',
-    'at-rule-no-unknown': true,
     'at-rule-no-vendor-prefix': true,
     'at-rule-semicolon-space-before': 'never',
     'block-closing-brace-empty-line-before': null,
@@ -34,7 +33,6 @@ module.exports = {
     'max-empty-lines': 2,
     'max-line-length': null,
     'media-feature-name-no-vendor-prefix': true,
-    'media-feature-range-operator-space-before': 'never',
     'no-descending-specificity': null,
     'number-leading-zero': 'never',
     'order/properties-order': [
@@ -259,7 +257,6 @@ module.exports = {
     'selector-max-class': 4,
     'selector-max-combinators': 4,
     'selector-max-compound-selectors': 4,
-    'selector-max-empty-lines': 1,
     'selector-max-id': 0,
     'selector-max-specificity': null,
     'selector-max-type': 2,


### PR DESCRIPTION
There 2 cases that our rules differ

* at-rule-no-unknown is set to true in stylelint-config-recommended
* selector-max-empty-lines, we had this to 1 for some reason, it's 0 in stylelint-config-standard
* media-feature-range-operator-space-before is always in stylelint-config-standard which makes more sense