### PR TITLE
Make SCSS dependencies optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,20 @@ Default stylelint config used by Bootstrap.
 
 ## Installation
 
+### CSS config (default):
+
 ```bash
 npm install stylelint-config-twbs-bootstrap --save-dev
 # Or with yarn:
 yarn add stylelint-config-twbs-bootstrap --dev
+```
+
+### SCSS config:
+
+```bash
+npm install stylelint-config-twbs-bootstrap stylelint-scss stylelint-config-recommended-scss --save-dev
+# Or with yarn:
+yarn add stylelint-config-twbs-bootstrap stylelint-scss stylelint-config-recommended-scss --dev
 ```
 
 ## Usage

--- a/package-lock.json
+++ b/package-lock.json
@@ -770,7 +770,8 @@
     "cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -1670,7 +1671,8 @@
     "indexes-of": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
-      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
+      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -2081,17 +2083,20 @@
     "lodash.isboolean": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
+      "dev": true
     },
     "lodash.isregexp": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isregexp/-/lodash.isregexp-4.0.1.tgz",
-      "integrity": "sha1-4T5kezDNVZdSoEzZEghvr32hwws="
+      "integrity": "sha1-4T5kezDNVZdSoEzZEghvr32hwws=",
+      "dev": true
     },
     "lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
+      "dev": true
     },
     "log-symbols": {
       "version": "3.0.0",
@@ -2641,7 +2646,8 @@
     "postcss-media-query-parser": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
-      "integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ="
+      "integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ=",
+      "dev": true
     },
     "postcss-reporter": {
       "version": "6.0.1",
@@ -2669,7 +2675,8 @@
     "postcss-resolve-nested-selector": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
-      "integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4="
+      "integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4=",
+      "dev": true
     },
     "postcss-safe-parser": {
       "version": "4.0.1",
@@ -2703,6 +2710,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
       "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
+      "dev": true,
       "requires": {
         "cssesc": "^3.0.0",
         "indexes-of": "^1.0.1",
@@ -2727,7 +2735,8 @@
     "postcss-value-parser": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
-      "integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ=="
+      "integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -3533,6 +3542,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-4.1.0.tgz",
       "integrity": "sha512-4012ca0weVi92epm3RRBRZcRJIyl5vJjJ/tJAKng+Qat5+cnmuCwyOI2vXkKdjNfGd0gvzyKCKEkvTMDcbtd7Q==",
+      "dev": true,
       "requires": {
         "stylelint-config-recommended": "^3.0.0"
       }
@@ -3559,6 +3569,7 @@
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.13.0.tgz",
       "integrity": "sha512-SaLnvQyndaPcsgVJsMh6zJ1uKVzkRZJx+Wg/stzoB1mTBdEmGketbHrGbMQNymzH/0mJ06zDSpeCDvNxqIJE5A==",
+      "dev": true,
       "requires": {
         "lodash.isboolean": "^3.0.3",
         "lodash.isregexp": "^4.0.1",
@@ -3793,7 +3804,8 @@
     "uniq": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+      "dev": true
     },
     "unist-util-find-all-after": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -28,17 +28,19 @@
     "node": ">=8.10.0"
   },
   "peerDependencies": {
-    "stylelint": "^10.1.0 || ^11.0.0 || ^12.0.0"
+    "stylelint": "^10.1.0 || ^11.0.0 || ^12.0.0",
+    "stylelint-config-recommended-scss": "^4.1.0",
+    "stylelint-scss": "^3.13.0"
   },
   "dependencies": {
-    "stylelint-config-recommended-scss": "^4.1.0",
     "stylelint-config-standard": "^19.0.0",
-    "stylelint-order": "^3.1.1",
-    "stylelint-scss": "^3.13.0"
+    "stylelint-order": "^3.1.1"
   },
   "devDependencies": {
     "eslint": "^6.6.0",
-    "stylelint": "^12.0.0"
+    "stylelint": "^12.0.0",
+    "stylelint-config-recommended-scss": "^4.0.0",
+    "stylelint-scss": "^3.12.1"
   },
   "scripts": {
     "eslint": "eslint --report-unused-disable-directives .",


### PR DESCRIPTION
This way, when one only needs CSS linting they don't need to have the extra SCSS dependencies.

---

This approach has its pros and cons... We do save a lot for people who don't need SCSS linting, but it requires the extra SCSS packages to be installed manually (like stylelint itself).

/CC @mdo @MartijnCuppens @ysds your thoughts?