### PR TITLE
CI: use `actions/checkout` to clone the upstream repo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Clone twbs/bootstrap repository
-        run: git clone https://github.com/twbs/bootstrap.git --depth 1
+        uses: actions/checkout@v2
+        with:
+          repository: twbs/bootstrap
+          path: bootstrap
 
       - name: Set up Node.js
         uses: actions/setup-node@v1


### PR DESCRIPTION
Not sure about this since the current solution also works