### PR TITLE
New rules

### DIFF
--- a/scss/index.js
+++ b/scss/index.js
@@ -11,10 +11,12 @@ module.exports = {
     'scss/at-function-pattern': '^[a-z][a-z-]*$',
     'scss/at-function-parentheses-space-before': 'never',
     'scss/at-import-no-partial-leading-underscore': true,
+    'scss/at-import-partial-extension': 'never',
     'scss/at-mixin-argumentless-call-parentheses': 'always',
     'scss/at-mixin-named-arguments': null,
     'scss/at-mixin-parentheses-space-before': 'never',
     'scss/at-rule-no-unknown': true,
+    'scss/dimension-no-non-numeric-values': true,
     'scss/dollar-variable-colon-space-after': 'at-least-one-space',
     'scss/dollar-variable-colon-space-before': 'never',
     'scss/dollar-variable-no-missing-interpolation': true,
@@ -32,6 +34,7 @@ module.exports = {
     'scss/no-duplicate-mixins': true,
     'scss/operator-no-newline-after': true,
     'scss/operator-no-newline-before': true,
-    'scss/operator-no-unspaced': true
+    'scss/operator-no-unspaced': true,
+    'scss/selector-no-redundant-nesting-selector': true
   }
 };


### PR DESCRIPTION
Not sure if we should disable these:

1. ~~scss/function-quote-no-quoted-strings-inside~~ Dropped
2. ~~scss/function-unquote-no-unquoted-strings-inside~~ Dropped

And also if we should enable any of these here or upstream:

1. ~~scss/function-color-relative: haven't tested it~~
2. ~~scss/partial-no-import: haven't tested it~~
3. ~~scss/selector-nest-combinators: this results in a lot of errors, so it might not be worth it~~
4. scss/selector-no-union-class-name: I guess this makes more sense to do it upstream to allow BEM

BTW It might be a good chance to enable map-keys-quotes since there's an issue about it already (#35). It shouldn't be considered a BC anyway in core, right?

EDIT: upstream branch which I test here against: https://github.com/twbs/bootstrap/compare/master-xmr-scss-rules

TODO:

- [ ] Revert the Action branch change before merging